### PR TITLE
Fix Mozilla Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
         <h3>&lt;h1&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -307,7 +307,7 @@
         <h3>&lt;h2&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -355,7 +355,7 @@
         <h3>&lt;dfn&gt;</h3>
         <p>Term being defined by the parent section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/dfn">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -363,7 +363,7 @@
         <h3>&lt;em&gt;</h3>
         <p>Text that should be emphasised.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/em">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -451,7 +451,7 @@
         <h3>&lt;h3&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -523,7 +523,7 @@
         <h3>&lt;strong&gt;</h3>
         <p>Text that is important.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/strong">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -539,7 +539,7 @@
         <h3>&lt;kbd&gt;</h3>
         <p>Example input (usually keyboard) for a program.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/kbd">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -595,7 +595,7 @@
         <h3>&lt;h4&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -651,7 +651,7 @@
         <h3>&lt;var&gt;</h3>
         <p>Mathematical or programming variable.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/var">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -737,7 +737,7 @@
         <h3>&lt;h5&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -785,7 +785,7 @@
         <h3>&lt;cite&gt;</h3>
         <p>Title of a referenced piece of work.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/cite">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -793,7 +793,7 @@
         <h3>&lt;samp&gt;</h3>
         <p>Sample output of a program.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/samp">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -825,7 +825,7 @@
         <h3>&lt;code&gt;</h3>
         <p>Fragment of code.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/phrase_elements">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/code">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/text-level-semantics.html">W3C Reference</a></li>
         </ul>
       </div>
@@ -881,7 +881,7 @@
         <h3>&lt;h6&gt;</h3>
         <p>Heading for the current section.</p>
         <ul class="links">
-          <li><a href="https://developer.mozilla.org/en/HTML/Element/hn/">Mozilla</a></li>
+          <li><a href="https://developer.mozilla.org/en/HTML/Element/Heading_Elements">Mozilla</a></li>
           <li><a href="http://www.w3.org/TR/html5/sections.html">W3C Reference</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Fixes #2 
Update Mozilla Developer Network Links for:
https://developer.mozilla.org/en/HTML/Element/phrase_elements
https://developer.mozilla.org/en/HTML/Element/hn/
